### PR TITLE
Fixing nexus 5x rootfs download issue

### DIFF
--- a/pm-flash
+++ b/pm-flash
@@ -52,17 +52,17 @@ download()
     if [ "$2" == "neon" ]; then
         ROOTFS_NAME=`curl -s https://images.plasma-mobile.org/rootfs/ | grep -E -o "pm-rootfs-[0-9-]+\.tar\.gz" | sort | tail -n 1`
         wget -c "https://images.plasma-mobile.org/rootfs/$ROOTFS_NAME" -P rootfs
-        ln -sf rootfs/pm-rootfs-$ROOTFS_NAME.tar.gz pm-rootfs-latest.tar.gz
+        ln -sf rootfs/pm-rootfs-$ROOTFS_NAME pm-rootfs-latest.tar.gz
     fi
     if [ "$2" == "arch" ]; then
         ROOTFS_NAME=`curl -s https://images.plasma-mobile.org/arch-rootfs/ | grep -E -o "pm-rootfs-[0-9-]+\.tar\.gz" | sort | tail -n 1`
         wget -c "https://images.plasma-mobile.org/arch-rootfs/$ROOTFS_NAME" -P rootfs
-        ln -sf rootfs/pm-rootfs-$ROOTFS_NAME.tar.gz pm-rootfs-latest.tar.gz
+        ln -sf rootfs/pm-rootfs-$ROOTFS_NAME pm-rootfs-latest.tar.gz
     fi
     if [ "$2" == "edge" ]; then
         ROOTFS_NAME=`curl -s https://images.plasma-mobile.org/edge-rootfs/ | grep -E -o "pm-rootfs-[0-9-]+\.tar\.gz" | sort | tail -n 1`
         wget -c "https://images.plasma-mobile.org/edge-rootfs/$ROOTFS_NAME" -P rootfs
-        ln -sf rootfs/pm-rootfs-$ROOTFS_NAME.tar.gz pm-rootfs-latest.tar.gz
+        ln -sf rootfs/pm-rootfs-$ROOTFS_NAME pm-rootfs-latest.tar.gz
     fi
     echo "[done]"
 

--- a/pm-flash
+++ b/pm-flash
@@ -47,7 +47,7 @@ download()
 
     echo "Downloading latest rootfs ... "
     [ -z `command -v curl` ] && (echo "required package 'curl' is missing, install via your package manager" && exit)
-    ping images.plasma-mobile.org -c 1 -W 1 > /dev/null 2>&1 || echo "failed to connect to 'images.plasma-mobile.org', check your internet connection"
+    ping images.plasma-mobile.org -c 1 -W 1 > /dev/null 2>&1 || (echo "failed to connect to 'images.plasma-mobile.org', check your internet connection" && exit)
 
     if [ "$2" == "neon" ]; then
         ROOTFS_NAME=`curl -s https://images.plasma-mobile.org/rootfs/ | grep -E -o "pm-rootfs-[0-9-]+\.tar\.gz" | sort | tail -n 1`

--- a/pm-flash
+++ b/pm-flash
@@ -51,17 +51,17 @@ download()
 
     if [ "$2" == "neon" ]; then
         ROOTFS_NAME=`curl -s https://images.plasma-mobile.org/rootfs/ | grep -E -o "pm-rootfs-[0-9-]+\.tar\.gz" | sort | tail -n 1`
-        wget -c "https://images.plasma-mobile.org/rootfs/pm-rootfs-$ROOTFS_NAME.tar.gz" -P rootfs
+        wget -c "https://images.plasma-mobile.org/rootfs/$ROOTFS_NAME" -P rootfs
         ln -sf rootfs/pm-rootfs-$ROOTFS_NAME.tar.gz pm-rootfs-latest.tar.gz
     fi
     if [ "$2" == "arch" ]; then
         ROOTFS_NAME=`curl -s https://images.plasma-mobile.org/arch-rootfs/ | grep -E -o "pm-rootfs-[0-9-]+\.tar\.gz" | sort | tail -n 1`
-        wget -c "https://images.plasma-mobile.org/arch-rootfs/pm-rootfs-$ROOTFS_NAME.tar.gz" -P rootfs
+        wget -c "https://images.plasma-mobile.org/arch-rootfs/$ROOTFS_NAME" -P rootfs
         ln -sf rootfs/pm-rootfs-$ROOTFS_NAME.tar.gz pm-rootfs-latest.tar.gz
     fi
     if [ "$2" == "edge" ]; then
         ROOTFS_NAME=`curl -s https://images.plasma-mobile.org/edge-rootfs/ | grep -E -o "pm-rootfs-[0-9-]+\.tar\.gz" | sort | tail -n 1`
-        wget -c "https://images.plasma-mobile.org/edge-rootfs/pm-rootfs-$ROOTFS_NAME.tar.gz" -P rootfs
+        wget -c "https://images.plasma-mobile.org/edge-rootfs/$ROOTFS_NAME" -P rootfs
         ln -sf rootfs/pm-rootfs-$ROOTFS_NAME.tar.gz pm-rootfs-latest.tar.gz
     fi
     echo "[done]"

--- a/pm-flash
+++ b/pm-flash
@@ -47,6 +47,7 @@ download()
 
     echo "Downloading latest rootfs ... "
     [ -z `command -v curl` ] && (echo "required package 'curl' is missing, install via your package manager" && exit)
+    ping images.plasma-mobile.org -c 1 -W 1 > /dev/null 2>&1 || echo "failed to connect to 'images.plasma-mobile.org', check your internet connection"
 
     if [ "$2" == "neon" ]; then
         ROOTFS_NAME=`curl -s https://images.plasma-mobile.org/rootfs/ | grep -E -o "pm-rootfs-[0-9-]+\.tar\.gz" | sort | tail -n 1`

--- a/pm-flash
+++ b/pm-flash
@@ -46,20 +46,22 @@ download()
     mkdir -p $CACHEDIR/ && pushd $CACHEDIR/
 
     echo "Downloading latest rootfs ... "
+    [ -z `command -v curl` ] && (echo "required package 'curl' is missing, install via your package manager" && exit)
+
     if [ "$2" == "neon" ]; then
-        ROOTFS_VERSION=`curl https://images.plasma-mobile.org/rootfs_stamp 2> /dev/null`
-        wget -c "https://images.plasma-mobile.org/rootfs/pm-rootfs-$ROOTFS_VERSION.tar.gz" -P rootfs
-        ln -sf rootfs/pm-rootfs-$ROOTFS_VERSION.tar.gz pm-rootfs-latest.tar.gz
+        ROOTFS_NAME=`curl -s https://images.plasma-mobile.org/rootfs/ | grep -E -o "pm-rootfs-[0-9-]+\.tar\.gz" | sort | tail -n 1`
+        wget -c "https://images.plasma-mobile.org/rootfs/pm-rootfs-$ROOTFS_NAME.tar.gz" -P rootfs
+        ln -sf rootfs/pm-rootfs-$ROOTFS_NAME.tar.gz pm-rootfs-latest.tar.gz
     fi
     if [ "$2" == "arch" ]; then
-        ROOTFS_VERSION=`curl https://images.plasma-mobile.org/arch_rootfs_stamp 2> /dev/null`
-        wget -c "https://images.plasma-mobile.org/arch-rootfs/pm-rootfs-$ROOTFS_VERSION.tar.gz" -P rootfs
-        ln -sf rootfs/pm-rootfs-$ROOTFS_VERSION.tar.gz pm-rootfs-latest.tar.gz
+        ROOTFS_NAME=`curl -s https://images.plasma-mobile.org/arch-rootfs/ | grep -E -o "pm-rootfs-[0-9-]+\.tar\.gz" | sort | tail -n 1`
+        wget -c "https://images.plasma-mobile.org/arch-rootfs/pm-rootfs-$ROOTFS_NAME.tar.gz" -P rootfs
+        ln -sf rootfs/pm-rootfs-$ROOTFS_NAME.tar.gz pm-rootfs-latest.tar.gz
     fi
     if [ "$2" == "edge" ]; then
-        ROOTFS_VERSION=`curl https://images.plasma-mobile.org/edge_rootfs_stamp 2> /dev/null`
-        wget -c "https://images.plasma-mobile.org/edge-rootfs/pm-rootfs-$ROOTFS_VERSION.tar.gz" -P rootfs
-        ln -sf rootfs/pm-rootfs-$ROOTFS_VERSION.tar.gz pm-rootfs-latest.tar.gz
+        ROOTFS_NAME=`curl -s https://images.plasma-mobile.org/edge-rootfs/ | grep -E -o "pm-rootfs-[0-9-]+\.tar\.gz" | sort | tail -n 1`
+        wget -c "https://images.plasma-mobile.org/edge-rootfs/pm-rootfs-$ROOTFS_NAME.tar.gz" -P rootfs
+        ln -sf rootfs/pm-rootfs-$ROOTFS_NAME.tar.gz pm-rootfs-latest.tar.gz
     fi
     echo "[done]"
 


### PR DESCRIPTION
issues cropped up when the rootfs_stamp was removed from the server.

this is a quick and dirty fix to poll the available options and take the latest version.

BE WARNED: while i have fixed the specific issues i have not got a device to test on with me, so I dont know what happens next. Dont get angry with me if you break your phone.

side issues:
curl is an implicit dependency and not always installled on host, log helpful message and exit if its not available
if the connection to host server is broken it now shows helpful message